### PR TITLE
call `html_escape` on string values

### DIFF
--- a/lib/so_meta/helper.rb
+++ b/lib/so_meta/helper.rb
@@ -19,7 +19,7 @@ module SoMeta
     def so_meta_interpolation(name, hash)
       variable_name = "@so_meta_#{name}_interpolation"
       interpolation = instance_variable_get(variable_name) || {}
-      hash.transform_values! { |v| h(v) }
+      hash.transform_values! { |v| html_escape(v) }
       instance_variable_set(variable_name, interpolation.merge(hash))
     end
   end

--- a/lib/so_meta/helper.rb
+++ b/lib/so_meta/helper.rb
@@ -19,6 +19,7 @@ module SoMeta
     def so_meta_interpolation(name, hash)
       variable_name = "@so_meta_#{name}_interpolation"
       interpolation = instance_variable_get(variable_name) || {}
+      hash.transform_values! { |v| h(v) }
       instance_variable_set(variable_name, interpolation.merge(hash))
     end
   end

--- a/lib/so_meta/version.rb
+++ b/lib/so_meta/version.rb
@@ -1,3 +1,3 @@
 module SoMeta
-  VERSION = "0.9"
+  VERSION = "0.10"
 end

--- a/so_meta.gemspec
+++ b/so_meta.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+
+  spec.add_runtime_dependency "erb"
 end


### PR DESCRIPTION
When passing values into the hash, this will escape HTML entities to avoid XSS issues.

This makes Rails a pre-requisite, since it's relying on `html_escape` to be available.

```ruby
# Example

so_meta_interpolation(:title, name: "javascript:/*--></title><script>alert('Hello')</script>")

# Before
so_meta(:title)
=> "Edit javascript:/*--></title><script>alert('Hello')</script>"

# After
so_meta(:title)
=> "Edit javascript:/*--&gt;&lt;/title&gt;&lt;script&gt;alert(&#39;Hello&#39;)&lt;/script&gt;"
```