### PR TITLE
Remove ERB gem dependency

### DIFF
--- a/lib/so_meta/version.rb
+++ b/lib/so_meta/version.rb
@@ -1,3 +1,3 @@
 module SoMeta
-  VERSION = "0.10"
+  VERSION = "0.11"
 end

--- a/so_meta.gemspec
+++ b/so_meta.gemspec
@@ -21,6 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-
-  spec.add_runtime_dependency "erb"
 end


### PR DESCRIPTION
Ruby includes ERB and the gem changes some of the classes from the standard library and interferes with sprockets processing.